### PR TITLE
Remove reference to style option in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,6 @@ const DOMParser = require("xmldom").DOMParser;
 const kml = new DOMParser().parseFromString(fs.readFileSync("foo.kml", "utf8"));
 
 const converted = tj.kml(kml);
-
-const convertedWithStyles = tj.kml(kml, { styles: true });
 ```
 
 ## ES Modules


### PR DESCRIPTION
I noticed that the README shows a special "style" option for the kml function, but looking in the source that doesn't actually exist and styles are always parsed, so I removed that line of the README.