### PR TITLE
Add `tcxGen` to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Convert KML and GPX to GeoJSON.
+# Convert KML, GPX, and TCX to GeoJSON.
 
 _togeojson development is supported by 🌎 [placemark.io](https://placemark.io/)_
 
@@ -52,6 +52,12 @@ that yields output feature by feature.
 ### `toGeoJSON.tcx(doc)`
 
 Convert a TCX document to GeoJSON. The first argument, `doc`, must be a TCX
+document as an XML DOM - not as a string.
+
+### `toGeoJSON.tcxGen(doc)`
+
+Convert a TCX document to GeoJSON incrementally, returning a [Generator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators)
+that yields output feature by feature. The first argument, `doc`, must be a TCX
 document as an XML DOM - not as a string.
 
 ## Property conversions


### PR DESCRIPTION
`tcxGen` is [exported](https://github.com/placemark/togeojson/blob/e41bf035827c9f00493b4445d53fd5da0844a58e/index.js#L2) but not documented in the README. This adds a short blurb to the README including this function.