### PR TITLE
Support CascadingStyle wrapper

### DIFF
--- a/lib/kml.js
+++ b/lib/kml.js
@@ -284,9 +284,19 @@ export function* kmlGen(doc) {
   const styleMaps = doc.getElementsByTagName("StyleMap");
 
   for (let k = 0; k < styles.length; k++) {
-    const hash = okhash(xml2str(styles[k])).toString(16);
-    styleIndex["#" + styles[k].getAttribute("id")] = hash;
-    styleByHash[hash] = styles[k];
+    const style = styles[k];
+    const hash = okhash(xml2str(style)).toString(16);
+    let id = style.getAttribute("id");
+    if (
+      !id &&
+      style.parentNode.tagName.replace("gx:", "") === "CascadingStyle"
+    ) {
+      id =
+        style.parentNode.getAttribute("kml:id") ||
+        style.parentNode.getAttribute("id");
+    }
+    styleIndex["#" + id] = hash;
+    styleByHash[hash] = style;
   }
   for (let l = 0; l < styleMaps.length; l++) {
     styleIndex["#" + styleMaps[l].getAttribute("id")] = okhash(

--- a/tap-snapshots/test/index.test.js.test.cjs
+++ b/tap-snapshots/test/index.test.js.test.cjs
@@ -21122,6 +21122,101 @@ Object {
 }
 `
 
+exports[`test/index.test.js TAP toGeoJSON > styles.kml 1`] = `
+Object {
+  "features": Array [
+    Object {
+      "geometry": Object {
+        "coordinates": Array [
+          21.00062301000721,
+          48.77257131826958,
+          1011.317797185818,
+        ],
+        "type": "Point",
+      },
+      "id": "00A083AD2520769B213A",
+      "properties": Object {
+        "description": "<div>Ahoj <b>PM</b></div>",
+        "fill": "#ffffff",
+        "fill-opacity": 0.25098039215686274,
+        "icon": "https://earth.google.com/earth/rpc/cc/icon?color=1976d2&id=2006&scale=4",
+        "icon-offset": Array [
+          64,
+          128,
+        ],
+        "name": "Untitled Placemark",
+        "stroke": "#fbc02d",
+        "stroke-opacity": 1,
+        "stroke-width": 2.13333,
+        "styleHash": "-42577181",
+        "styleMapHash": Object {
+          "highlight": "#__managed_style_21BB934A3420769B4A67",
+          "normal": "#__managed_style_1AF19DBC7E20769B4A67",
+        },
+        "styleUrl": "#__managed_style_04D1BA179420769B4A67",
+      },
+      "type": "Feature",
+    },
+    Object {
+      "geometry": Object {
+        "coordinates": Array [
+          Array [
+            Array [
+              20.99533143425753,
+              48.76385474037835,
+              817.5844849086294,
+            ],
+            Array [
+              21.00506376944139,
+              48.76355632184772,
+              896.3736545453368,
+            ],
+            Array [
+              21.00499721332549,
+              48.77057344889175,
+              1026.856093377534,
+            ],
+            Array [
+              20.99495695589513,
+              48.77073832155815,
+              991.0859038879247,
+            ],
+            Array [
+              20.99533143425753,
+              48.76385474037835,
+              817.5844849086294,
+            ],
+          ],
+        ],
+        "type": "Polygon",
+      },
+      "id": "0F66A23B9820769D44FC",
+      "properties": Object {
+        "fill": "#ffee58",
+        "fill-opacity": 0.25098039215686274,
+        "icon": "https://earth.google.com/earth/rpc/cc/icon?color=1976d2&id=2000&scale=4",
+        "icon-offset": Array [
+          64,
+          128,
+        ],
+        "name": "Untitled Polygon",
+        "stroke": "#303f9f",
+        "stroke-opacity": 1,
+        "stroke-width": 2.13333,
+        "styleHash": "1b52cb1d",
+        "styleMapHash": Object {
+          "highlight": "#__managed_style_24D42D73B520769D5922",
+          "normal": "#__managed_style_1CAC85685820769D5922",
+        },
+        "styleUrl": "#__managed_style_01C13F4A1E20769D5922",
+      },
+      "type": "Feature",
+    },
+  ],
+  "type": "FeatureCollection",
+}
+`
+
 exports[`test/index.test.js TAP toGeoJSON > tcx-courses.tcx 1`] = `
 Object {
   "features": Array [

--- a/test/data/styles.kml
+++ b/test/data/styles.kml
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:kml="http://www.opengis.net/kml/2.2" xmlns:atom="http://www.w3.org/2005/Atom">
+<Document>
+	<name>Project 2</name>
+	<gx:CascadingStyle kml:id="__managed_style_24D42D73B520769D5922">
+		<Style>
+			<IconStyle>
+				<scale>1.2</scale>
+				<Icon>
+					<href>https://earth.google.com/earth/rpc/cc/icon?color=1976d2&amp;id=2000&amp;scale=4</href>
+				</Icon>
+				<hotSpot x="64" y="128" xunits="pixels" yunits="insetPixels"/>
+			</IconStyle>
+			<LabelStyle>
+			</LabelStyle>
+			<LineStyle>
+				<color>ff9f3f30</color>
+				<width>3.2</width>
+			</LineStyle>
+			<PolyStyle>
+				<color>4058eeff</color>
+			</PolyStyle>
+			<BalloonStyle>
+				<displayMode>hide</displayMode>
+			</BalloonStyle>
+		</Style>
+	</gx:CascadingStyle>
+	<gx:CascadingStyle kml:id="__managed_style_1CAC85685820769D5922">
+		<Style>
+			<IconStyle>
+				<Icon>
+					<href>https://earth.google.com/earth/rpc/cc/icon?color=1976d2&amp;id=2000&amp;scale=4</href>
+				</Icon>
+				<hotSpot x="64" y="128" xunits="pixels" yunits="insetPixels"/>
+			</IconStyle>
+			<LabelStyle>
+			</LabelStyle>
+			<LineStyle>
+				<color>ff9f3f30</color>
+				<width>2.13333</width>
+			</LineStyle>
+			<PolyStyle>
+				<color>4058eeff</color>
+			</PolyStyle>
+			<BalloonStyle>
+				<displayMode>hide</displayMode>
+			</BalloonStyle>
+		</Style>
+	</gx:CascadingStyle>
+	<StyleMap id="__managed_style_01C13F4A1E20769D5922">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#__managed_style_1CAC85685820769D5922</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#__managed_style_24D42D73B520769D5922</styleUrl>
+		</Pair>
+	</StyleMap>
+	<gx:CascadingStyle kml:id="__managed_style_1AF19DBC7E20769B4A67">
+		<styleUrl>https://earth.google.com/balloon_components/base/1.0.23.0/card_template.kml#main</styleUrl>
+		<Style>
+			<IconStyle>
+				<Icon>
+					<href>https://earth.google.com/earth/rpc/cc/icon?color=1976d2&amp;id=2006&amp;scale=4</href>
+				</Icon>
+				<hotSpot x="64" y="128" xunits="pixels" yunits="insetPixels"/>
+			</IconStyle>
+			<LabelStyle>
+			</LabelStyle>
+			<LineStyle>
+				<color>ff2dc0fb</color>
+				<width>2.13333</width>
+			</LineStyle>
+			<PolyStyle>
+				<color>40ffffff</color>
+			</PolyStyle>
+			<BalloonStyle>
+			</BalloonStyle>
+		</Style>
+	</gx:CascadingStyle>
+	<StyleMap id="__managed_style_04D1BA179420769B4A67">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#__managed_style_1AF19DBC7E20769B4A67</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#__managed_style_21BB934A3420769B4A67</styleUrl>
+		</Pair>
+	</StyleMap>
+	<gx:CascadingStyle kml:id="__managed_style_2DB21B970C20769AE403">
+		<Style>
+			<IconStyle>
+				<scale>1.2</scale>
+				<Icon>
+					<href>https://earth.google.com/earth/rpc/cc/icon?color=1976d2&amp;id=2000&amp;scale=4</href>
+				</Icon>
+				<hotSpot x="64" y="128" xunits="pixels" yunits="insetPixels"/>
+			</IconStyle>
+			<LabelStyle>
+			</LabelStyle>
+			<LineStyle>
+				<color>ff2dc0fb</color>
+				<width>3.2</width>
+			</LineStyle>
+			<PolyStyle>
+				<color>40ffffff</color>
+			</PolyStyle>
+			<BalloonStyle>
+				<displayMode>hide</displayMode>
+			</BalloonStyle>
+		</Style>
+	</gx:CascadingStyle>
+	<gx:CascadingStyle kml:id="__managed_style_21BB934A3420769B4A67">
+		<styleUrl>https://earth.google.com/balloon_components/base/1.0.23.0/card_template.kml#main</styleUrl>
+		<Style>
+			<IconStyle>
+				<scale>1.2</scale>
+				<Icon>
+					<href>https://earth.google.com/earth/rpc/cc/icon?color=1976d2&amp;id=2006&amp;scale=4</href>
+				</Icon>
+				<hotSpot x="64" y="128" xunits="pixels" yunits="insetPixels"/>
+			</IconStyle>
+			<LabelStyle>
+			</LabelStyle>
+			<LineStyle>
+				<color>ff2dc0fb</color>
+				<width>3.2</width>
+			</LineStyle>
+			<PolyStyle>
+				<color>40ffffff</color>
+			</PolyStyle>
+			<BalloonStyle>
+			</BalloonStyle>
+		</Style>
+	</gx:CascadingStyle>
+	<gx:CascadingStyle kml:id="__managed_style_142BB2EF4920769AE403">
+		<Style>
+			<IconStyle>
+				<Icon>
+					<href>https://earth.google.com/earth/rpc/cc/icon?color=1976d2&amp;id=2000&amp;scale=4</href>
+				</Icon>
+				<hotSpot x="64" y="128" xunits="pixels" yunits="insetPixels"/>
+			</IconStyle>
+			<LabelStyle>
+			</LabelStyle>
+			<LineStyle>
+				<color>ff2dc0fb</color>
+				<width>2.13333</width>
+			</LineStyle>
+			<PolyStyle>
+				<color>40ffffff</color>
+			</PolyStyle>
+			<BalloonStyle>
+				<displayMode>hide</displayMode>
+			</BalloonStyle>
+		</Style>
+	</gx:CascadingStyle>
+	<StyleMap id="__managed_style_089915520820769AE403">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#__managed_style_142BB2EF4920769AE403</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#__managed_style_2DB21B970C20769AE403</styleUrl>
+		</Pair>
+	</StyleMap>
+	<Folder id="0A0E71079B20769AE402">
+		<name>Untitled Folder</name>
+		<styleUrl>#__managed_style_089915520820769AE403</styleUrl>
+	</Folder>
+	<Placemark id="00A083AD2520769B213A">
+		<name>Untitled Placemark</name>
+		<description><![CDATA[<div>Ahoj <b>PM</b></div>]]></description>
+		<LookAt>
+			<longitude>21.03627280967009</longitude>
+			<latitude>48.75792341699059</latitude>
+			<altitude>889.3921860247805</altitude>
+			<heading>0</heading>
+			<tilt>0</tilt>
+			<gx:fovy>35</gx:fovy>
+			<range>13555.65298660425</range>
+			<altitudeMode>absolute</altitudeMode>
+		</LookAt>
+		<styleUrl>#__managed_style_04D1BA179420769B4A67</styleUrl>
+		<Point>
+			<coordinates>21.00062301000721,48.77257131826958,1011.317797185818</coordinates>
+		</Point>
+	</Placemark>
+	<Placemark id="0F66A23B9820769D44FC">
+		<name>Untitled Polygon</name>
+		<LookAt>
+			<longitude>21.03453909453304</longitude>
+			<latitude>48.764924539933</latitude>
+			<altitude>921.0732592320394</altitude>
+			<heading>0</heading>
+			<tilt>0</tilt>
+			<gx:fovy>35</gx:fovy>
+			<range>13523.97273127455</range>
+			<altitudeMode>absolute</altitudeMode>
+		</LookAt>
+		<styleUrl>#__managed_style_01C13F4A1E20769D5922</styleUrl>
+		<Polygon>
+			<outerBoundaryIs>
+				<LinearRing>
+					<coordinates>
+						20.99533143425753,48.76385474037835,817.5844849086294 21.00506376944139,48.76355632184772,896.3736545453368 21.00499721332549,48.77057344889175,1026.856093377534 20.99495695589513,48.77073832155815,991.0859038879247 20.99533143425753,48.76385474037835,817.5844849086294 
+					</coordinates>
+				</LinearRing>
+			</outerBoundaryIs>
+		</Polygon>
+	</Placemark>
+</Document>
+</kml>


### PR DESCRIPTION
- Fixes #60

Google Earth exports a "gx:CascadingStyle" element, which is undocumented by Google or the OGC. This PR adds ad-hoc support for this element by the following logic:

- If a Style element has no id, check to see if it's in a CascadingStyle element with an id
- If so, use the CascadingStyle element's id as its own.