### PR TITLE
Update link to the repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/placemarkio/togeojson.git"
+    "url": "git://github.com/placemark/togeojson.git"
   },
   "license": "BSD-2-Clause",
   "keywords": [


### PR DESCRIPTION
Noticed while browsing the npm package for the project that these links would give a 404:

![image](https://user-images.githubusercontent.com/591645/175119600-9d01d5f6-0cb6-42d0-abe3-3efded869977.png)