### PR TITLE
Add support for KML schema

### DIFF
--- a/lib/__snapshots__/index.test.ts.snap
+++ b/lib/__snapshots__/index.test.ts.snap
@@ -21730,6 +21730,122 @@ Object {
 }
 `;
 
+exports[`toGeoJSON schema.kml 1`] = `
+Object {
+  "features": Array [
+    Object {
+      "geometry": Object {
+        "coordinates": Array [
+          Array [
+            Array [
+              12.8206124,
+              55.9654246,
+            ],
+            Array [
+              12.8204862,
+              55.9654342,
+            ],
+            Array [
+              12.8204902,
+              55.9654507,
+            ],
+            Array [
+              12.8206164,
+              55.9654411,
+            ],
+            Array [
+              12.8206124,
+              55.9654246,
+            ],
+          ],
+        ],
+        "type": "Polygon",
+      },
+      "properties": Object {
+        "block_block_number": 1,
+        "cn_cv_1109": "89%",
+        "fill-opacity": 0,
+        "gid": 167001,
+        "plotno_plot_number": 167001,
+        "random": 0.9,
+        "random_2": 0.4,
+        "random_2_block": 41,
+        "random_2_trial": 39,
+        "random_block": 98,
+        "random_trial": 96,
+        "stroke": "#ff0000",
+        "stroke-opacity": 1,
+        "tream_treatment_number": "16",
+      },
+      "type": "Feature",
+    },
+  ],
+  "type": "FeatureCollection",
+}
+`;
+
+exports[`toGeoJSON schema.kml 2`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "geometry": Object {
+            "coordinates": Array [
+              Array [
+                Array [
+                  12.8206124,
+                  55.9654246,
+                ],
+                Array [
+                  12.8204862,
+                  55.9654342,
+                ],
+                Array [
+                  12.8204902,
+                  55.9654507,
+                ],
+                Array [
+                  12.8206164,
+                  55.9654411,
+                ],
+                Array [
+                  12.8206124,
+                  55.9654246,
+                ],
+              ],
+            ],
+            "type": "Polygon",
+          },
+          "properties": Object {
+            "block_block_number": 1,
+            "cn_cv_1109": "89%",
+            "fill-opacity": 0,
+            "gid": 167001,
+            "plotno_plot_number": 167001,
+            "random": 0.9,
+            "random_2": 0.4,
+            "random_2_block": 41,
+            "random_2_trial": 39,
+            "random_block": 98,
+            "random_trial": 96,
+            "stroke": "#ff0000",
+            "stroke-opacity": 1,
+            "tream_treatment_number": "16",
+          },
+          "type": "Feature",
+        },
+      ],
+      "meta": Object {
+        "name": "TES_124_167_28_JUL_2022_1109",
+      },
+      "type": "folder",
+    },
+  ],
+  "type": "root",
+}
+`;
+
 exports[`toGeoJSON selfclosing.kml 1`] = `
 Object {
   "features": Array [
@@ -21772,9 +21888,9 @@ Object {
         "type": "Point",
       },
       "properties": Object {
-        "ElevationGain": "10",
+        "ElevationGain": 10,
         "TrailHeadName": "Pi in the sky",
-        "TrailLength": "3.14159",
+        "TrailLength": 3.14159,
         "name": "Easy trail",
         "styleUrl": "#trailhead-balloon-template",
       },
@@ -21789,9 +21905,9 @@ Object {
         "type": "Point",
       },
       "properties": Object {
-        "ElevationGain": "10000",
+        "ElevationGain": 10000,
         "TrailHeadName": "Mount Everest",
-        "TrailLength": "347.45",
+        "TrailLength": 347.45,
         "name": "Difficult trail",
         "styleUrl": "#trailhead-balloon-template",
       },
@@ -21814,9 +21930,9 @@ Object {
         "type": "Point",
       },
       "properties": Object {
-        "ElevationGain": "10",
+        "ElevationGain": 10,
         "TrailHeadName": "Pi in the sky",
-        "TrailLength": "3.14159",
+        "TrailLength": 3.14159,
         "name": "Easy trail",
         "styleUrl": "#trailhead-balloon-template",
       },
@@ -21831,9 +21947,9 @@ Object {
         "type": "Point",
       },
       "properties": Object {
-        "ElevationGain": "10000",
+        "ElevationGain": 10000,
         "TrailHeadName": "Mount Everest",
-        "TrailLength": "347.45",
+        "TrailLength": 347.45,
         "name": "Difficult trail",
         "styleUrl": "#trailhead-balloon-template",
       },

--- a/lib/kml.ts
+++ b/lib/kml.ts
@@ -12,6 +12,7 @@ import {
   isElement,
   normalizeId,
 } from "./shared";
+import { Schema, typeConverters } from "./kml/shared";
 
 /**
  * A folder including metadata. Folders
@@ -76,6 +77,16 @@ function buildStyleMap(node: Document): StyleMap {
     });
   }
   return styleMap;
+}
+
+function buildSchema(node: Document): Schema {
+  const schema: Schema = {};
+  for (const field of $(node, "SimpleField")) {
+    schema[field.getAttribute("name") || ""] =
+      typeConverters[field.getAttribute("type") || ""] ||
+      typeConverters["string"];
+  }
+  return schema;
 }
 
 const FOLDER_PROPS = [
@@ -146,6 +157,7 @@ function getFolder(node: Element): Folder {
  */
 export function kmlWithFolders(node: Document): Root {
   const styleMap = buildStyleMap(node);
+  const schema = buildSchema(node);
 
   // atomic geospatial types supported by KML - MultiGeometry is
   // handled separately
@@ -169,7 +181,7 @@ export function kmlWithFolders(node: Document): Root {
         }
         case "Placemark": {
           placemarks.push(node);
-          const placemark = getPlacemark(node, styleMap);
+          const placemark = getPlacemark(node, styleMap, schema);
           if (placemark) {
             pointer.children.push(placemark);
           }
@@ -203,8 +215,9 @@ export function kmlWithFolders(node: Document): Root {
  */
 export function* kmlGen(node: Document): Generator<F> {
   const styleMap = buildStyleMap(node);
+  const schema = buildSchema(node);
   for (const placemark of $(node, "Placemark")) {
-    const feature = getPlacemark(placemark, styleMap);
+    const feature = getPlacemark(placemark, styleMap, schema);
     if (feature) yield feature;
   }
   for (const groundOverlay of $(node, "GroundOverlay")) {

--- a/lib/kml/placemark.ts
+++ b/lib/kml/placemark.ts
@@ -6,6 +6,7 @@ import {
   extractTimeSpan,
   extractTimeStamp,
   getMaybeHTMLDescription,
+  Schema,
 } from "./shared";
 import { extractStyle } from "./extractStyle";
 import { getGeometry } from "./geometry";
@@ -23,7 +24,8 @@ function geometryListToGeometry(geometries: Geometry[]): Geometry | null {
 
 export function getPlacemark(
   node: Element,
-  styleMap: StyleMap
+  styleMap: StyleMap,
+  schema: Schema
 ): Feature<Geometry | null> {
   const { coordTimes, geometries } = getGeometry(node);
 
@@ -42,7 +44,7 @@ export function getPlacemark(
       getMaybeHTMLDescription(node),
       extractCascadedStyle(node, styleMap),
       extractStyle(node),
-      extractExtendedData(node),
+      extractExtendedData(node, schema),
       extractTimeSpan(node),
       extractTimeStamp(node),
       coordTimes.length

--- a/test/data/schema.kml
+++ b/test/data/schema.kml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+	<Document id="root_doc">
+		<Schema name="TES_124_167_28_JUL_2022_1109" id="TES_124_167_28_JUL_2022_1109">
+			<SimpleField name="gid" type="float"></SimpleField>
+			<SimpleField name="plotno_plot_number" type="float"></SimpleField>
+			<SimpleField name="tream_treatment_number" type="string"></SimpleField>
+			<SimpleField name="block_block_number" type="float"></SimpleField>
+			<SimpleField name="random" type="float"></SimpleField>
+			<SimpleField name="random_2" type="float"></SimpleField>
+			<SimpleField name="random_trial" type="int"></SimpleField>
+			<SimpleField name="random_2_trial" type="int"></SimpleField>
+			<SimpleField name="random_block" type="int"></SimpleField>
+			<SimpleField name="random_2_block" type="int"></SimpleField>
+			<SimpleField name="cn_cv_1109" type="string"></SimpleField>
+		</Schema>
+		<Folder>
+			<name>TES_124_167_28_JUL_2022_1109</name>
+			<Placemark>
+				<Style>
+					<LineStyle>
+						<color>ff0000ff</color>
+					</LineStyle>
+					<PolyStyle>
+						<fill>0</fill>
+					</PolyStyle>
+				</Style>
+				<ExtendedData>
+					<SchemaData schemaUrl="#TES_124_167_28_JUL_2022_1109">
+						<SimpleData name="gid">167001</SimpleData>
+						<SimpleData name="plotno_plot_number">167001</SimpleData>
+						<SimpleData name="tream_treatment_number">16</SimpleData>
+						<SimpleData name="block_block_number">1</SimpleData>
+						<SimpleData name="random">0.9</SimpleData>
+						<SimpleData name="random_2">0.4</SimpleData>
+						<SimpleData name="random_trial">96</SimpleData>
+						<SimpleData name="random_2_trial">39</SimpleData>
+						<SimpleData name="random_block">98</SimpleData>
+						<SimpleData name="random_2_block">41</SimpleData>
+						<SimpleData name="cn_cv_1109">89%</SimpleData>
+					</SchemaData>
+				</ExtendedData>
+				<Polygon>
+					<outerBoundaryIs>
+						<LinearRing>
+							<coordinates>12.8206124,55.9654246 12.8204862,55.9654342 12.8204902,55.9654507 12.8206164,55.9654411 12.8206124,55.9654246</coordinates>
+						</LinearRing>
+					</outerBoundaryIs>
+				</Polygon>
+			</Placemark>
+		</Folder>
+	</Document>
+</kml>


### PR DESCRIPTION
This addresses #69, support for KML schemas.

With this PR, the GeoJSON features will have properties with datatypes matching the input KML schema, instead of all properties being converted to strings.
