### PR TITLE
adds types definitions to exports in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "module": "dist/togeojson.es.mjs",
   "main": "dist/togeojson.cjs",
   "exports": {
+    "types": "./dist/index.d.ts",
     "require": "./dist/togeojson.cjs",
     "default": "./dist/togeojson.es.mjs"
   },


### PR DESCRIPTION
This fixes https://github.com/placemark/togeojson/issues/108 .