### PR TITLE
Fix tests: `zero_elevation.gpx` and `extractStyle`

### DIFF
--- a/lib/__snapshots__/index.test.ts.snap
+++ b/lib/__snapshots__/index.test.ts.snap
@@ -31011,6 +31011,7 @@ exports[`toGeoJSON > zero_elevation.gpx 1`] = `
           [
             -71.09622,
             42.210031,
+            0,
           ],
           [
             -71.096284,

--- a/lib/kml/extractStyle.test.ts
+++ b/lib/kml/extractStyle.test.ts
@@ -84,6 +84,7 @@ describe("extractStyle", () => {
         ],
         "icon-opacity": 1,
         "icon-scale": 1,
+        "label-scale": 0,
       }
     `);
   });

--- a/lib/shared.ts
+++ b/lib/shared.ts
@@ -86,7 +86,7 @@ export function num1(
 ) {
   const val = parseFloat(nodeVal(get1(node, tagName)));
   if (isNaN(val)) return undefined;
-  if (val && callback) callback(val);
+  if (callback) callback(val);
   return val;
 }
 


### PR DESCRIPTION
Fixes a regression introduced within [v4.8.0](https://github.com/placemark/togeojson/commit/6f36fd381798377909632eae11efef9e8b9be596#diff-b57612ddbc06606a1fac121785d7e76667762312b3c835af30b8b6bb4f78b1a3) refactoring.

Related to https://github.com/Raruto/leaflet-elevation/issues/259

## Troublesome example

```js
// <ele>0</ele> values shouldn't be interpreted as an empty ("false" or "undefined") value.

toGeoJSON.gpx(new DOMParser().parseFromString(
`<?xml version="1.0" encoding="UTF-8"?>
<gpx version="1.0" xmlns="http://www.topografix.com/GPX/1/0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <trk>
    <trkseg>
      <trkpt lat="45.763340000" lon="12.843770000">
        <ele>-1.000</ele>
      </trkpt>
      <trkpt lat="45.763240000" lon="12.847620000">
        <ele>0</ele>
      </trkpt>
    </trkseg>
  </trk>
</gpx>`, "text/xml"))
```

# @tmcw/togeojson (v6.5.0)

```json
{
  "type": "FeatureCollection",
  "features": [
    {
      "type": "Feature",
      "properties": {
        "_gpxType": "trk",
        "coordinateProperties": {}
      },
      "geometry": {
        "type": "LineString",
        "coordinates": [
          [
            12.84377,
            45.76334,
            -1
          ],
          [
            12.84762,
            45.76324
          ]
        ]
      }
    }
  ]
}
```

# @tmcw/togeojson (v4.6.0)

```json
{
  "type": "FeatureCollection",
  "features": [
    {
      "type": "Feature",
      "properties": {
        "_gpxType": "trk"
      },
      "geometry": {
        "type": "LineString",
        "coordinates": [
          [
            12.84377,
            45.76334,
            -1
          ],
          [
            12.84762,
            45.76324,
            0
          ]
        ]
      }
    }
  ]
}
```

👋 Raruto