### PR TITLE
GroundOverlay box

### DIFF
--- a/lib/__snapshots__/index.test.ts.snap
+++ b/lib/__snapshots__/index.test.ts.snap
@@ -12769,6 +12769,12 @@ exports[`toGeoJSON > ground_overlay.kml 1`] = `
 {
   "features": [
     {
+      "bbox": [
+        14.60128369746704,
+        37.46543388598137,
+        15.35832653742206,
+        37.91904192681665,
+      ],
       "geometry": {
         "coordinates": [
           [
@@ -12816,6 +12822,12 @@ exports[`toGeoJSON > ground_overlay.kml 2`] = `
     {
       "children": [
         {
+          "bbox": [
+            14.60128369746704,
+            37.46543388598137,
+            15.35832653742206,
+            37.91904192681665,
+          ],
           "geometry": {
             "coordinates": [
               [


### PR DESCRIPTION
- Fixes #112

toGeoJSON does not by default produce `bbox` properties because they can be derived from existing GeoJSON data, but in this case a GroundOverlay does very literally suggest a box, and it doesn't hurt to represent that box literally in the output.

This only applies to GroundOverlays with aligned rectangles specified by LatLonBox, and not those specified by `<gx:LatLonQuad>`, which can contain rotated boxes. Also, the bbox generated is literal - if a `rotation` is also provided, it is not incorporated into the `bbox`.