### PR TITLE
Gpx metadata type

### DIFF
--- a/lib/gpx/metadata.ts
+++ b/lib/gpx/metadata.ts
@@ -1,0 +1,33 @@
+import { $, getMulti, nodeVal } from "../shared";
+
+export function extractMetadata(node: Document) {
+  const properties = getMulti(node, [
+    "name",
+    "desc",
+    "author",
+    // "copyright",
+    "time",
+    "keywords",
+  ]);
+  const extensions = Array.from(
+    node.getElementsByTagNameNS(
+      "http://www.garmin.com/xmlschemas/GpxExtensions/v3",
+      "*"
+    )
+  );
+  for (const child of extensions) {
+    if (child.parentNode?.parentNode === node) {
+      properties[child.tagName.replace(":", "_")] = nodeVal(child);
+    }
+  }
+  const links = $(node, "link");
+  if (links.length) {
+    properties.links = links.map((link) =>
+      Object.assign(
+        { href: link.getAttribute("href") },
+        getMulti(link, ["text", "type"])
+      )
+    );
+  }
+  return properties;
+}


### PR DESCRIPTION
Hi Tom,

here's a draft based on: https://github.com/placemark/togeojson/issues/111#issuecomment-1577380801, that is, add a dedicated feature identified by the `"_gpxType": "metadata"` property ():

```jsonc
{
  "type": "FeatureCollection",
  "features": [
    {
      "type": "Feature",
      "geometry": {
        "type": "Polygon",
        "coordinates": [ ]     // eventually populated by https://www.topografix.com/GPX/1/1/#type_boundsType
      },
      "properties": {
        "_gpxType": "metadata" // everything else related to https://www.topografix.com/GPX/1/1/#type_metadataType
        "name": "...",
        "desc": "...",
        "author": {
            "name": "...",
            "email": "",
            "link": {
               "href": "...",
               "text": "...",
               "type": "...",
            }
        },
        "copyright": {
          "author": "...",
          "year": "...",
          "license": "..."
        },
        "time": "...",
        "keywords": "...",
        "extensions": ??
    },
    {
      // Other features
    }
  ]
}
```

Let me know, so I'll eventually update the tests accordingly.

👋 Raruto