### PR TITLE
Make external interfaces compatible with xmldom

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ with Polygon geometries. They have two defined properties:
 
 Both `gx:LatLonQuad` and `LatLonBox`-based ground overlays are supported.
 
+## TypeScript
+
+Install the `@types/geojson` package alongside this for its types
+to work. This will also use types from `@xmldom/xmldom` as
+input types if it's available.
+
 ## CLI
 
 Use [@tmcw/togeojson-cli](https://github.com/tmcw/togeojson-cli) to use this

--- a/README.md
+++ b/README.md
@@ -60,9 +60,17 @@ Both `gx:LatLonQuad` and `LatLonBox`-based ground overlays are supported.
 
 ## TypeScript
 
-Install the `@types/geojson` package alongside this for its types
-to work. This will also use types from `@xmldom/xmldom` as
-input types if it's available.
+If you're using this with TypeScript, you'll want to also install:
+
+- `@types/geojson`
+- `@xmldom/xmldom`
+
+These will give you accurate types for both input and output
+types. Due to TypeScript limitations, it's currently necessary
+to install `@xmldom/xmldom` for accurate input types even
+if you aren't using that module for parsing XML.
+If you have ideas for how to improve this, please
+[comment on this PR!](https://github.com/placemark/togeojson/pull/138).
 
 ## CLI
 

--- a/lib/kml.ts
+++ b/lib/kml.ts
@@ -1,4 +1,5 @@
 import type { FeatureCollection, Geometry } from "geojson";
+import type { Document as XDocument } from "@xmldom/xmldom";
 import { extractStyle } from "./kml/extractStyle";
 import { getGroundOverlay } from "./kml/ground_overlay";
 import { getPlacemark } from "./kml/placemark";
@@ -174,13 +175,14 @@ function getFolder(node: Element): Folder {
  * on which map framework you're using.
  */
 export function kmlWithFolders(
-  node: Document,
+  node: Document | XDocument,
   options: KMLOptions = {
     skipNullGeometry: false,
   }
 ): Root {
-  const styleMap = buildStyleMap(node);
-  const schema = buildSchema(node);
+  const n = node as Document;
+  const styleMap = buildStyleMap(n);
+  const schema = buildSchema(n);
 
   // atomic geospatial types supported by KML - MultiGeometry is
   // handled separately
@@ -227,7 +229,7 @@ export function kmlWithFolders(
     }
   }
 
-  traverse(node, tree, options);
+  traverse(n, tree, options);
 
   return tree;
 }
@@ -238,18 +240,19 @@ export function kmlWithFolders(
  * that yields output feature by feature.
  */
 export function* kmlGen(
-  node: Document,
+  node: Document | XDocument,
   options: KMLOptions = {
     skipNullGeometry: false,
   }
 ): Generator<F> {
-  const styleMap = buildStyleMap(node);
-  const schema = buildSchema(node);
-  for (const placemark of $(node, "Placemark")) {
+  const n = node as Document;
+  const styleMap = buildStyleMap(n);
+  const schema = buildSchema(n);
+  for (const placemark of $(n, "Placemark")) {
     const feature = getPlacemark(placemark, styleMap, schema, options);
     if (feature) yield feature;
   }
-  for (const groundOverlay of $(node, "GroundOverlay")) {
+  for (const groundOverlay of $(n, "GroundOverlay")) {
     const feature = getGroundOverlay(groundOverlay, styleMap, schema, options);
     if (feature) yield feature;
   }
@@ -266,13 +269,13 @@ export function* kmlGen(
  * or use it directly in libraries.
  */
 export function kml(
-  node: Document,
+  node: Document | XDocument,
   options: KMLOptions = {
     skipNullGeometry: false,
   }
 ): FeatureCollection<Geometry | null> {
   return {
     type: "FeatureCollection",
-    features: Array.from(kmlGen(node, options)),
+    features: Array.from(kmlGen(node as Document, options)),
   };
 }

--- a/lib/kml.ts
+++ b/lib/kml.ts
@@ -1,5 +1,5 @@
-import type { FeatureCollection, Geometry } from "geojson";
 import type { Document as XDocument } from "@xmldom/xmldom";
+import type { FeatureCollection, Geometry } from "geojson";
 import { extractStyle } from "./kml/extractStyle";
 import { getGroundOverlay } from "./kml/ground_overlay";
 import { getPlacemark } from "./kml/placemark";

--- a/lib/tcx.ts
+++ b/lib/tcx.ts
@@ -1,3 +1,4 @@
+import type { Document as XDocument } from "@xmldom/xmldom";
 import type { Feature, FeatureCollection, Position } from "geojson";
 import { $, type P, get, get1, nodeVal, num1 } from "./shared";
 
@@ -181,13 +182,13 @@ function getLap(node: Element): Feature | null {
  * first argument, `doc`, must be a TCX
  * document as an XML DOM - not as a string.
  */
-export function* tcxGen(node: Document): Generator<Feature> {
-  for (const lap of $(node, "Lap")) {
+export function* tcxGen(node: Document | XDocument): Generator<Feature> {
+  for (const lap of $(node as Document, "Lap")) {
     const feature = getLap(lap);
     if (feature) yield feature;
   }
 
-  for (const course of $(node, "Courses")) {
+  for (const course of $(node as Document, "Courses")) {
     const feature = getLap(course);
     if (feature) yield feature;
   }
@@ -197,7 +198,7 @@ export function* tcxGen(node: Document): Generator<Feature> {
  * Convert a TCX document to GeoJSON. The first argument, `doc`, must be a TCX
  * document as an XML DOM - not as a string.
  */
-export function tcx(node: Document): FeatureCollection {
+export function tcx(node: Document | XDocument): FeatureCollection {
   return {
     type: "FeatureCollection",
     features: Array.from(tcxGen(node)),

--- a/package.json
+++ b/package.json
@@ -26,16 +26,12 @@
     "prepare": "rollup -c rollup.config.mjs",
     "release": "standard-version"
   },
-  "peerDependencies": {
-    "@types/geojson": "*",
-    "@xmldom/xmldom": "^0.9.5"
-  },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@placemarkio/check-geojson": "^0.1.12",
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^12.1.2",
-    "@types/geojson": "^7946.0.16",
+    "@types/geojson": "*",
     "@vitest/coverage-v8": "^3.0.4",
     "@xmldom/xmldom": "^0.9.7",
     "rollup": "^4.32.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@tmcw/togeojson",
-  "version": "6.0.1",
+  "version": "6.0.2-0",
   "description": "convert KML and GPX to GeoJSON",
   "source": "lib/index.ts",
   "umd:main": "dist/togeojson.umd.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
         specifier: ^12.1.2
         version: 12.1.2(rollup@4.32.0)(tslib@2.8.1)(typescript@5.7.3)
       '@types/geojson':
-        specifier: ^7946.0.16
+        specifier: '*'
         version: 7946.0.16
       '@vitest/coverage-v8':
         specifier: ^3.0.4


### PR DESCRIPTION
- Fixes #132 
- Fixes #133

This resolves two fairly long-standing issues. It does two things:

1. Removes `@types/geojson` and `@xmldom/xmldom` as peerDependencies. If you want to use them and their types with TypeScript, you install those packages separately.
2. Adds a union type for all `Document` parameters that go into the module to signal compatibility with xmldom.