### PR TITLE
Adding Processing of NetworkLink KML Tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ coverage
 node_modules/
 npm-debug.log
 .nyc_output
+/.vscode/
+/.idea/

--- a/lib/__snapshots__/index.test.ts.snap
+++ b/lib/__snapshots__/index.test.ts.snap
@@ -21115,6 +21115,125 @@ exports[`toGeoJSON > multitrackgpx.gpx 1`] = `
 }
 `;
 
+exports[`toGeoJSON > networklink.kml 1`] = `
+{
+  "features": [],
+  "type": "FeatureCollection",
+}
+`;
+
+exports[`toGeoJSON > networklink.kml 2`] = `
+{
+  "children": [
+    {
+      "bbox": [
+        15.086756,
+        53.180102,
+        16.775049,
+        53.357038,
+      ],
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              15.086756,
+              53.357038,
+            ],
+            [
+              16.775049,
+              53.357038,
+            ],
+            [
+              16.775049,
+              53.180102,
+            ],
+            [
+              15.086756,
+              53.180102,
+            ],
+            [
+              15.086756,
+              53.357038,
+            ],
+          ],
+        ],
+        "type": "Polygon",
+      },
+      "properties": {
+        "@geometry-type": "networklink",
+        "href": "https://tiny.url",
+        "lod": [
+          128,
+          -1,
+          null,
+          null,
+        ],
+        "timestamp": "2023",
+        "viewRefreshMode": "onRequest",
+      },
+      "type": "Feature",
+    },
+  ],
+  "type": "root",
+}
+`;
+
+exports[`toGeoJSON > networklink.kml 3`] = `
+{
+  "children": [
+    {
+      "bbox": [
+        15.086756,
+        53.180102,
+        16.775049,
+        53.357038,
+      ],
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              15.086756,
+              53.357038,
+            ],
+            [
+              16.775049,
+              53.357038,
+            ],
+            [
+              16.775049,
+              53.180102,
+            ],
+            [
+              15.086756,
+              53.180102,
+            ],
+            [
+              15.086756,
+              53.357038,
+            ],
+          ],
+        ],
+        "type": "Polygon",
+      },
+      "properties": {
+        "@geometry-type": "networklink",
+        "href": "https://tiny.url",
+        "lod": [
+          128,
+          -1,
+          null,
+          null,
+        ],
+        "timestamp": "2023",
+        "viewRefreshMode": "onRequest",
+      },
+      "type": "Feature",
+    },
+  ],
+  "type": "root",
+}
+`;
+
 exports[`toGeoJSON > nogeomplacemark.kml 1`] = `
 {
   "features": [

--- a/lib/kml.ts
+++ b/lib/kml.ts
@@ -2,6 +2,7 @@ import type { Document as XDocument } from "@xmldom/xmldom";
 import type { FeatureCollection, Geometry } from "geojson";
 import { extractStyle } from "./kml/extractStyle";
 import { getGroundOverlay } from "./kml/ground_overlay";
+import { getNetworkLink } from "./kml/networklink";
 import { getPlacemark } from "./kml/placemark";
 import { type Schema, typeConverters } from "./kml/shared";
 import {
@@ -188,6 +189,7 @@ export function kmlWithFolders(
   // handled separately
   // all root placemarks in the file
   const placemarks = [];
+  const networkLinks = [];
   const tree: Root = { type: "root", children: [] };
 
   function traverse(
@@ -217,6 +219,14 @@ export function kmlWithFolders(
           const folder = getFolder(node);
           pointer.children.push(folder);
           pointer = folder;
+          break;
+        }
+        case "NetworkLink": {
+          networkLinks.push(node);
+          const networkLink = getNetworkLink(node, styleMap, schema, options);
+          if (networkLink) {
+            pointer.children.push(networkLink);
+          }
           break;
         }
       }

--- a/lib/kml/ground_overlay.ts
+++ b/lib/kml/ground_overlay.ts
@@ -4,6 +4,7 @@ import { type StyleMap, get1, getMulti, num1 } from "../shared";
 import { extractIconHref, extractStyle } from "./extractStyle";
 import { coord, fixRing, getCoordinates } from "./geometry";
 import {
+  type BBox,
   type Schema,
   extractCascadedStyle,
   extractExtendedData,
@@ -32,8 +33,6 @@ function getGroundOverlayBox(node: Element): BoxGeometry | null {
 
   return getLatLonBox(node);
 }
-
-type BBox = [number, number, number, number];
 
 const DEGREES_TO_RADIANS = Math.PI / 180;
 

--- a/lib/kml/networklink.ts
+++ b/lib/kml/networklink.ts
@@ -1,0 +1,195 @@
+import type { Feature, Polygon } from "geojson";
+import type { KMLOptions } from "lib/kml";
+import { type StyleMap, get1, getMulti, num1 } from "../shared";
+import { extractIconHref, extractStyle } from "./extractStyle";
+import {
+  AltitudeMode,
+  type BBox,
+  type Schema,
+  extractCascadedStyle,
+  extractExtendedData,
+  extractTimeSpan,
+  extractTimeStamp,
+  getMaybeHTMLDescription,
+  processAltitudeMode,
+} from "./shared";
+
+interface BoxGeometry {
+  bbox?: BBox;
+  geometry: Polygon;
+}
+
+type LOD = [number, number | null, number | null, number | null];
+interface IRegion {
+  coordinateBox: BoxGeometry | null;
+  lod: LOD | null;
+}
+
+function getNetworkLinkRegion(node: Element): IRegion | null {
+  const region = get1(node, "Region");
+
+  if (region) {
+    return {
+      coordinateBox: getLatLonAltBox(region),
+      lod: getLod(node),
+    };
+  }
+  return null;
+}
+
+function getLod(node: Element): LOD | null {
+  const lod = get1(node, "Lod");
+
+  if (lod) {
+    return [
+      num1(lod, "minLodPixels") ?? -1,
+      num1(lod, "maxLodPixels") ?? -1,
+      num1(lod, "minFadeExtent") ?? null,
+      num1(lod, "maxFadeExtent") ?? null,
+    ];
+  }
+
+  return null;
+}
+
+function getLatLonAltBox(node: Element): BoxGeometry | null {
+  const latLonAltBox = get1(node, "LatLonAltBox");
+
+  if (latLonAltBox) {
+    const north = num1(latLonAltBox, "north");
+    const west = num1(latLonAltBox, "west");
+    const east = num1(latLonAltBox, "east");
+    const south = num1(latLonAltBox, "south");
+    const altitudeMode = processAltitudeMode(
+      get1(latLonAltBox, "altitudeMode") ||
+        get1(latLonAltBox, "gx:altitudeMode")
+    );
+
+    if (altitudeMode) {
+      if (
+        typeof north === "number" &&
+        typeof south === "number" &&
+        typeof west === "number" &&
+        typeof east === "number"
+      ) {
+        const bbox: BBox = [west, south, east, north];
+        const coordinates = [
+          [
+            [west, north], // top left
+            [east, north], // top right
+            [east, south], // top right
+            [west, south], // bottom left
+            [west, north], // top left (again)
+          ],
+        ];
+        return {
+          bbox,
+          geometry: {
+            type: "Polygon",
+            coordinates,
+          },
+        };
+      }
+    } else {
+      console.debug(
+        "Encountered an unsupported feature of KML for togeojson: please contact developers for support of altitude mode."
+      );
+    }
+  }
+
+  return null;
+}
+
+function getLinkObject(node: Element) {
+  /*
+    <Link id="ID">
+      <!-- specific to Link -->
+      <href>...</href>                      <!-- string -->
+      <refreshMode>onChange</refreshMode>
+        <!-- refreshModeEnum: onChange, onInterval, or onExpire -->
+      <refreshInterval>4</refreshInterval>  <!-- float -->
+      <viewRefreshMode>never</viewRefreshMode>
+        <!-- viewRefreshModeEnum: never, onStop, onRequest, onRegion -->
+      <viewRefreshTime>4</viewRefreshTime>  <!-- float -->
+      <viewBoundScale>1</viewBoundScale>    <!-- float -->
+      <viewFormat>BBOX=[bboxWest],[bboxSouth],[bboxEast],[bboxNorth]</viewFormat>
+                                            <!-- string -->
+      <httpQuery>...</httpQuery>            <!-- string -->
+    </Link>
+  */
+  const linkObj = get1(node, "Link");
+
+  if (linkObj) {
+    return getMulti(linkObj, [
+      "href",
+      "refreshMode",
+      "refreshInterval",
+      "viewRefreshMode",
+      "viewRefreshTime",
+      "viewBoundScale",
+      "viewFormat",
+      "httpQuery",
+    ]);
+  }
+
+  return {};
+}
+
+export function getNetworkLink(
+  node: Element,
+  styleMap: StyleMap,
+  schema: Schema,
+  options: KMLOptions
+): Feature<Polygon | null> | null {
+  const box = getNetworkLinkRegion(node);
+
+  const geometry = box?.coordinateBox?.geometry || null;
+
+  if (!geometry && options.skipNullGeometry) {
+    return null;
+  }
+
+  const feature: Feature<Polygon | null> = {
+    type: "Feature",
+    geometry,
+    properties: Object.assign(
+      /**
+       * Related to
+       * https://gist.github.com/tmcw/037a1cb6660d74a392e9da7446540f46
+       */
+      { "@geometry-type": "networklink" },
+      getMulti(node, [
+        "name",
+        "address",
+        "visibility",
+        "open",
+        "phoneNumber",
+        "styleUrl",
+        "refreshVisibility",
+        "flyToView",
+        "description",
+      ]),
+      getMaybeHTMLDescription(node),
+      extractCascadedStyle(node, styleMap),
+      extractStyle(node),
+      extractIconHref(node),
+      extractExtendedData(node, schema),
+      extractTimeSpan(node),
+      extractTimeStamp(node),
+      getLinkObject(node),
+      box?.lod ? { lod: box.lod } : {}
+    ),
+  };
+
+  if (box?.coordinateBox?.bbox) {
+    feature.bbox = box.coordinateBox.bbox;
+  }
+
+  if (feature.properties?.visibility !== undefined) {
+    feature.properties.visibility = feature.properties.visibility !== "0";
+  }
+
+  const id = node.getAttribute("id");
+  if (id !== null && id !== "") feature.id = id;
+  return feature;
+}

--- a/lib/kml/shared.ts
+++ b/lib/kml/shared.ts
@@ -83,3 +83,31 @@ export function extractCascadedStyle(node: Element, styleMap: StyleMap): P {
     return { styleUrl };
   });
 }
+
+export enum AltitudeMode {
+  ABSOLUTE = "absolute",
+  RELATIVE_TO_GROUND = "relativeToGround",
+  CLAMP_TO_GROUND = "clampToGround",
+  CLAMP_TO_SEAFLOOR = "clampToSeaFloor",
+  RELATIVE_TO_SEAFLOOR = "relativeToSeaFloor",
+}
+
+export function processAltitudeMode(mode: Element | null): AltitudeMode | null {
+  switch (mode?.textContent) {
+    case AltitudeMode.ABSOLUTE:
+      return AltitudeMode.ABSOLUTE;
+    case AltitudeMode.CLAMP_TO_GROUND:
+      return AltitudeMode.CLAMP_TO_GROUND;
+    case AltitudeMode.CLAMP_TO_SEAFLOOR:
+      return AltitudeMode.CLAMP_TO_SEAFLOOR;
+    case AltitudeMode.RELATIVE_TO_GROUND:
+      return AltitudeMode.RELATIVE_TO_GROUND;
+    case AltitudeMode.RELATIVE_TO_SEAFLOOR:
+      return AltitudeMode.RELATIVE_TO_SEAFLOOR;
+    default:
+      break;
+  }
+  return null;
+}
+
+export type BBox = [number, number, number, number];

--- a/test/data/networklink.kml
+++ b/test/data/networklink.kml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+  <Document>
+    <name>
+      <![CDATA[Test NetworkLink]]>
+    </name>
+    <Style>
+      <ListStyle>
+        <listItemType>checkHideChildren</listItemType>
+      </ListStyle>
+    </Style>
+    <NetworkLink>
+      <TimeStamp>
+        <when>2023</when>
+      </TimeStamp>
+      <Region>
+        <LatLonAltBox>
+          <north>53.357038</north>
+          <south>53.180102</south>
+          <east>16.775049</east>
+          <west>15.086756</west>
+        </LatLonAltBox>
+        <Lod>
+          <minLodPixels>128</minLodPixels>
+          <maxLodPixels>-1</maxLodPixels>
+        </Lod>
+      </Region>
+      <Link>
+        <viewRefreshMode>onRequest</viewRefreshMode>
+        <href>https://tiny.url</href>
+      </Link>
+    </NetworkLink>
+  </Document>
+</kml>


### PR DESCRIPTION
Whoops, @karlsosha - merged #139 but it was on an external PR branch so tests weren't actually running on that PR. I'll need to manually approve workflow runs for it. Reopened this as a revert-of-revert but you can open another matching PR if that works for you. The NetworkLink code was failing the snapshot tests for kmlWithFolders.

This reverts commit 9bcc746ce0f1f81c84fd1200abcc772538d43389.